### PR TITLE
Upgrade GitHub-maintained actions to latest major versions

### DIFF
--- a/.github/workflows/gitterra.yml
+++ b/.github/workflows/gitterra.yml
@@ -35,15 +35,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: gitterra
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "."
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- `actions/download-artifact` v4 → v8
- `actions/configure-pages` v4 → v6
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5

## Test plan
- [ ] Workflow runs successfully on merge to main
- [ ] Pages deployment completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)